### PR TITLE
Replace multiple entries with single entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Maven build directory
+target/
+
 # Compiled class file
 *.class
 
@@ -21,16 +24,9 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+# IDE specific config/settings files
 .vscode/
 .idea/
 *.iml
-target/maven-status/
-target/classes
-target/generated-sources
-target/generated-test-sources
-target/maven-archiver
-target/maven-status
-target/surefire-reports
-target/test-classes
 .classpath
 .settings/


### PR DESCRIPTION
Replace multiple target/sub-directoty with single entry.

We can *ignore the entire build output directory **target/*** - which anyway gets recreated during builds.

We can *avoid unnecessary tracking* of output .jar files (like **target/sdk-keygen-1.1.jar**), as well, as given below:

```
myMac:hedera-keygen-java admin$ git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	deleted:    target/original-sdk-keygen-1.1.jar
	deleted:    target/sdk-keygen-1.1.jar

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	BKP_working/
	_bkp_temp/
	command/

no changes added to commit (use "git add" and/or "git commit -a")
myMac:hedera-keygen-java admin$ 
```
